### PR TITLE
Remove unwraps, reorganizing where needed

### DIFF
--- a/examples/send_self.rs
+++ b/examples/send_self.rs
@@ -19,8 +19,7 @@ fn main() {
 
     let handle = bot.new_cmd("/send_self").and_then(|(bot, msg)| {
         bot.document(msg.chat.id)
-            .try_file("examples/send_self.rs")
-            .unwrap()
+            .file("examples/send_self.rs")
             .send()
     });
 

--- a/examples/send_self.rs
+++ b/examples/send_self.rs
@@ -19,7 +19,8 @@ fn main() {
 
     let handle = bot.new_cmd("/send_self").and_then(|(bot, msg)| {
         bot.document(msg.chat.id)
-            .file("examples/send_self.rs")
+            .try_file("examples/send_self.rs")
+            .unwrap()
             .send()
     });
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -129,7 +129,12 @@ impl Bot {
 
         // add properties
         for (key, val) in msg.iter() {
-            form.part(key).contents(format!("{}", val).as_bytes()).add()?;
+            let val = match val {
+                &Value::String(ref val) => format!("{}", val),
+                etc => format!("{}", etc),
+            };
+
+            form.part(key).contents(val.as_bytes()).add()?;
         }
 
         form.part(kind)

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -65,7 +65,7 @@ impl Bot {
     pub fn fetch_json(
         &self,
         func: &'static str,
-        msg: String,
+        msg: &str,
     ) -> impl Future<Item = String, Error = Error> {
         debug!("Send JSON: {}", msg);
 
@@ -74,7 +74,7 @@ impl Bot {
         self._fetch(func, json)
     }
 
-    fn build_json(&self, msg: String) -> Result<Easy, Error> {
+    fn build_json(&self, msg: &str) -> Result<Easy, Error> {
         let mut header = List::new();
 
         header.append("Content-Type: application/json")?;
@@ -94,7 +94,7 @@ impl Bot {
     pub fn fetch_formdata<T>(
         &self,
         func: &'static str,
-        msg: Value,
+        msg: &Value,
         file: T,
         kind: &str,
         file_name: &str,
@@ -111,7 +111,7 @@ impl Bot {
 
     fn build_formdata<T>(
         &self,
-        msg: Value,
+        msg: &Value,
         mut file: T,
         kind: &str,
         file_name: &str,
@@ -166,10 +166,10 @@ impl Bot {
             .and_then(move |a| {
                 session
                     .perform(a)
-                    .map_err(|x| Error::TokioCurl(x))
+                    .map_err(Error::TokioCurl)
                     .map(|_| response_vec)
                     .and_then(move |response_vec| {
-                        let ref vec = response_vec.lock()?;
+                        let vec = &(response_vec.lock()?);
                         let s = str::from_utf8(vec)?;
 
                         let x = String::from(s);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
 use std::io;
+use std::str;
+use std::sync::PoisonError;
+use serde_json::Error as JsonError;
 use curl::Error as CurlError;
 use curl::FormError;
 use tokio_curl::PerformError;
@@ -23,6 +26,24 @@ pub enum Error {
     JSON,
     // indicates an unknown error
     Unknown,
+}
+
+impl From<JsonError> for Error {
+    fn from(_: JsonError) -> Self {
+        Error::JSON
+    }
+}
+
+impl<T> From<PoisonError<T>> for Error {
+    fn from(_: PoisonError<T>) -> Self {
+        Error::Unknown
+    }
+}
+
+impl From<str::Utf8Error> for Error {
+    fn from(_: str::Utf8Error) -> Self {
+        Error::UTF8Decode
+    }
 }
 
 impl From<PerformError> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,6 @@
+use std::io;
+use curl::Error as CurlError;
+use curl::FormError;
 use tokio_curl::PerformError;
 
 #[derive(Debug)]
@@ -7,11 +10,41 @@ pub enum Error {
     UTF8Decode,
     // indicates a Telegram error (e.g. a property is missing)
     Telegram(String),
-    // indicates some failure in CURL, missing network connection etc.
+    // indicates some failure in Tokio-CURL, missing network connection etc.
     TokioCurl(PerformError),
+    // indicates some failure in CURL, failed to configure request, etc.
+    Curl(CurlError),
+    // indicates some failure in Curl's Form module, failed to build request, etc.
+    Form(FormError),
+    // indicates an error reading or writing data
+    IO(io::Error),
     // indicates a malformated reply, this should never happen unless the Telegram server has a
     // hard time
     JSON,
     // indicates an unknown error
     Unknown,
+}
+
+impl From<PerformError> for Error {
+    fn from(err: PerformError) -> Self {
+        Error::TokioCurl(err)
+    }
+}
+
+impl From<CurlError> for Error {
+    fn from(err: CurlError) -> Self {
+        Error::Curl(err)
+    }
+}
+
+impl From<FormError> for Error {
+    fn from(err: FormError) -> Self {
+        Error::Form(err)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::IO(err)
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     // indicates a malformated reply, this should never happen unless the Telegram server has a
     // hard time
     JSON,
+    // indicates whether a file was supposed to be attached, but wasn't properly read
+    NoFile,
     // indicates an unknown error
     Unknown,
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -27,14 +27,16 @@ impl<'a> TryFrom<&'a str> for File {
 }
 
 /// Construct a Telegram file from an object which implements the Read trait
-impl<'a, S: Read + 'static> From<(&'a str, S)> for File {
-    fn from((path, source): (&'a str, S)) -> File
+impl<'a, S: Read + 'static> TryFrom<(&'a str, S)> for File {
+    type Error = io::Error;
+
+    fn try_from((path, source): (&'a str, S)) -> Result<Self, Self::Error>
     where
         S: Read + 'static,
     {
-        File {
+        Ok(File {
             name: path.into(),
             source: Box::new(source),
-        }
+        })
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -2,8 +2,9 @@
 //!
 //! The filename should be such that it represents the content type.
 
-use std::io::Read;
+use std::io::{self, Read};
 use std::fs;
+use std::convert::TryFrom;
 
 /// A Telegram file which contains a readable source and a filename
 pub struct File {
@@ -12,14 +13,16 @@ pub struct File {
 }
 
 /// Construct a Telegram file from a local path
-impl<'a> From<&'a str> for File {
-    fn from(path: &'a str) -> File {
-        let file = fs::File::open(path).unwrap();
+impl<'a> TryFrom<&'a str> for File {
+    type Error = io::Error;
 
-        File {
+    fn try_from(path: &'a str) -> Result<Self, Self::Error> {
+        let file = fs::File::open(path)?;
+
+        Ok(File {
             name: path.into(),
             source: Box::new(file),
-        }
+        })
     }
 }
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -10,6 +10,7 @@ use error::Error;
 use file;
 use futures::Future;
 use std::rc::Rc;
+use std::convert::TryInto;
 use erased_serde::Serialize;
 
 /// The strongly typed version of the parse_mode field which indicates the type of text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 
 #![feature(conservative_impl_trait)]
 #![feature(custom_attribute)]
+#![feature(try_from)]
 #![allow(unused_attributes)]
 
 #[macro_use]

--- a/telebot-derive/src/lib.rs
+++ b/telebot-derive/src/lib.rs
@@ -261,7 +261,7 @@ fn expand_function(ast: syn::MacroInput) -> quote::Tokens {
                             return Err((tmp, Error::Unknown));
                         })
                         .and_then(move |(tmp, msg, file)| {
-                            tmp.bot.fetch_formdata(#function, msg, file.source, #bot_function_name, &file.name)
+                            tmp.bot.fetch_formdata(#function, &msg, file.source, #bot_function_name, &file.name)
                                 .map_err(|err| (tmp, err))
                         })
                         .or_else(move |(tmp, err)| {
@@ -280,7 +280,7 @@ fn expand_function(ast: syn::MacroInput) -> quote::Tokens {
                                 })
                                 .into_future()
                                 .and_then(move |msg| {
-                                    bot.fetch_json(#function, msg)
+                                    bot.fetch_json(#function, &msg)
                                 })
                         })
                         .and_then(move |answer| {
@@ -348,7 +348,7 @@ fn expand_function(ast: syn::MacroInput) -> quote::Tokens {
                     result(serde_json::to_string(&self.inner))
                         .map_err(|e| e.into())
                         .and_then(move |msg| {
-                            let obj = self.bot.fetch_json(#function, msg)
+                            let obj = self.bot.fetch_json(#function, &msg)
                                 .and_then(move |x| {
                                     let bot = RcBot {
                                         inner: self.bot.clone(),


### PR DESCRIPTION
My project [AdminBot](https://github.com/asonix/telegram-admin-bot) has crashed a few times while I wasn't watching due to some `.unwrap()`s somewhere in the dependencies, but I haven't been able to isolate exactly where.

In order to avoid this issue, I've attempted to handle every case in Telebot where `.unwrap()` was used with some logic that doesn't involve panicking. In many places, this was doable by expanding on the `.and_then()` chains already present in the code.

I've done some light testing of these changes with my [Telecord](https://github.com/asonix/telecord) project, and verified that I can still send and receive text and files.

Some formatting unrelated to the `.unwrap()`s changed since my text editor automatically runs `rustfmt`