### PR TITLE
Reply Markup (and other small changes)

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -5,12 +5,12 @@
 use bot::{Bot, RcBot};
 use serde_json;
 use objects;
-use objects::{Integer, NotImplemented};
+use objects::Integer;
 use error::Error;
 use file;
 use futures::Future;
 use std::rc::Rc;
-use std::convert::TryInto;
+use std::convert::{From, TryInto};
 use erased_serde::Serialize;
 
 /// The strongly typed version of the parse_mode field which indicates the type of text
@@ -42,6 +42,53 @@ pub enum Action {
     UploadAudio,
     UploadDocument,
     FindLocation,
+}
+
+/// Possible types of reply markups
+pub enum ReplyMarkup {
+    InlineKeyboardMarkup(objects::InlineKeyboardMarkup),
+    ReplyKeyboardMarkup(objects::ReplyKeyboardMarkup),
+    ReplyKeyboardRemove(objects::ReplyKeyboardRemove),
+    ForceReply(objects::ForceReply)
+}
+
+impl ::serde::Serialize for ReplyMarkup {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: ::serde::Serializer
+    {
+        use self::ReplyMarkup::*;
+
+        match self {
+            &InlineKeyboardMarkup(ref x) => x.serialize(serializer),
+            &ReplyKeyboardMarkup(ref x) => x.serialize(serializer),
+            &ReplyKeyboardRemove(ref x) => x.serialize(serializer),
+            &ForceReply(ref x) => x.serialize(serializer),
+        }
+    }
+}
+
+impl From<objects::InlineKeyboardMarkup> for ReplyMarkup {
+    fn from(f: objects::InlineKeyboardMarkup) -> Self {
+        ReplyMarkup::InlineKeyboardMarkup(f)
+    }
+}
+
+impl From<objects::ReplyKeyboardMarkup> for ReplyMarkup {
+    fn from(f: objects::ReplyKeyboardMarkup) -> Self {
+        ReplyMarkup::ReplyKeyboardMarkup(f)
+    }
+}
+
+impl From<objects::ReplyKeyboardRemove> for ReplyMarkup {
+    fn from(f: objects::ReplyKeyboardRemove) -> Self {
+        ReplyMarkup::ReplyKeyboardRemove(f)
+    }
+}
+
+impl From<objects::ForceReply> for ReplyMarkup {
+    fn from(f: objects::ForceReply) -> Self {
+        ReplyMarkup::ForceReply(f)
+    }
 }
 
 impl Into<String> for Action {
@@ -101,7 +148,7 @@ pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send photos. On success, the sent Message is returned.
@@ -121,7 +168,7 @@ pub struct SendPhoto {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send audio files, if you want Telegram clients to display them in the music
@@ -151,7 +198,7 @@ pub struct SendAudio {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send general files. On success, the sent Message is returned. Bots can
@@ -173,7 +220,7 @@ pub struct SendDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send .webp stickers. On success, the sent Message is returned.
@@ -191,7 +238,7 @@ pub struct SendSticker {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send video files, Telegram clients support mp4 videos (other formats may be
@@ -219,7 +266,7 @@ pub struct SendVideo {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send audio files, if you want Telegram clients to display the file as a
@@ -245,7 +292,7 @@ pub struct SendVoice {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send point on the map. On success, the sent Message is returned.
@@ -262,7 +309,7 @@ pub struct SendLocation {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send information about a venue. On success, the sent Message is returned.
@@ -283,7 +330,7 @@ pub struct SendVenue {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method to send phone contacts. On success, the sent Message is returned.
@@ -301,7 +348,7 @@ pub struct SendContact {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_to_message_id: Option<Integer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reply_markup: Option<NotImplemented>,
+    reply_markup: Option<ReplyMarkup>,
 }
 
 /// Use this method when you need to tell the user that something is happening on the bot's side.

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -210,7 +210,7 @@ pub struct File {
 /// details and examples).
 #[derive(Deserialize, Debug)]
 pub struct ReplyKeyboardMarkup {
-    pub keyboard: Vec<KeyboardButton>,
+    pub keyboard: Vec<Vec<KeyboardButton>>,
     pub resize_keyboard: Option<bool>,
     pub one_time_keyboard: Option<bool>,
     pub selective: Option<bool>,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -98,7 +98,7 @@ pub struct Update {
     pub edited_channel_post: Option<Message>,
     pub inline_query: Option<InlineQuery>,
     pub chosen_inline_result: Option<()>,
-    pub callback_query: Option<()>,
+    pub callback_query: Option<CallbackQuery>,
 }
 
 /// This object represents one size of a photo or a file / sticker thumbnail.

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -208,21 +208,26 @@ pub struct File {
 
 /// This object represents a custom keyboard with reply options (see Introduction to bots for
 /// details and examples).
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ReplyKeyboardMarkup {
     pub keyboard: Vec<Vec<KeyboardButton>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resize_keyboard: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub one_time_keyboard: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }
 
 /// This object represents one button of the reply keyboard. For simple text buttons String can be
 /// used instead of this object to specify text of the button. Optional fields are mutually
 /// exclusive.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct KeyboardButton {
     pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_contact: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_location: Option<bool>,
 }
 
@@ -230,9 +235,10 @@ pub struct KeyboardButton {
 /// keyboard and display the default letter-keyboard. By default, custom keyboards are displayed
 /// until a new keyboard is sent by a bot. An exception is made for one-time keyboards that are
 /// hidden immediately after the user presses a button (see ReplyKeyboardMarkup).
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ReplyKeyboardRemove {
     pub remove_keyboard: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }
 
@@ -279,9 +285,10 @@ pub struct CallbackQuery {
 /// the user (act as if the user has selected the bot‘s message and tapped ’Reply'). This can be
 /// extremely useful if you want to create user-friendly step-by-step interfaces without having to
 /// sacrifice privacy mode.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ForceReply {
     pub force_reply: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }
 


### PR DESCRIPTION
Here's my stab at implementing a type for reply markup. I use an enum with a custom serialize implementation that just forwards to the inner type.

It ends up looking something like this:

```rust
        let button = KeyboardButton {
            text: "I am a BANANA".to_owned(),
            request_contact: None,
            request_location: None,
        };

        let buttons = vec![
            vec![button],
        ];

        let inline_keyboard = ReplyKeyboardMarkup {
            keyboard: buttons,
            one_time_keyboard: Some(true),
            resize_keyboard: None,
            selective: None,
        };

        self.tg.message(msg.chat.id, text).reply_markup(inline_keyboard).send().map(|_| ())
```