### PR TITLE
Fix #35: Accept for commands in "/command@bot" format

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -314,8 +314,15 @@ impl RcBot {
                 if let Some(ref mut message) = val.message {
                     if let Some(text) = message.text.clone() {
                         let mut content = text.split_whitespace();
-                        if let Some(cmd) = content.next() {
-                            if cmd.starts_with("/") {
+                        if let Some(command) = content.next() {
+                            if command.starts_with("/") {
+                                let cmd = {
+                                    if command.ends_with(&*self.inner.name.borrow().as_ref().unwrap().as_str()) {
+                                        &command[..(command.len() - self.inner.name.borrow().as_ref().unwrap().len() - 1)]
+                                    } else {
+                                        &command[..]
+                                    }
+                                };
                                 if let Some(sender) = self.inner.handlers.borrow_mut().get_mut(cmd)
                                 {
                                     sndr = Some(sender.clone());

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -2,6 +2,7 @@
 //! as an underlying field. You should always use RcBot.
 
 use objects;
+use functions::FunctionGetMe;
 use failure::{Error, Fail, ResultExt};
 use error::{ErrorKind, TelegramError};
 use file::File;
@@ -43,6 +44,7 @@ impl RcBot {
 /// The main bot structure
 pub struct Bot {
     pub key: String,
+    pub name: RefCell<Option<String>>,
     pub handle: Handle,
     pub last_id: Cell<u32>,
     pub update_interval: Cell<u64>,
@@ -58,6 +60,7 @@ impl Bot {
         Bot {
             handle: handle.clone(),
             key: key.into(),
+            name: RefCell::new(None),
             last_id: Cell::new(0),
             update_interval: Cell::new(1000),
             timeout: Cell::new(30),
@@ -340,6 +343,7 @@ impl RcBot {
 
     /// helper function to start the event loop
     pub fn run<'a>(&'a self, core: &mut Core) -> Result<(), Error> {
+        *self.inner.name.borrow_mut() = Some(core.run(self.get_me().send()).unwrap().1.username.unwrap());
         core.run(self.get_stream().for_each(|_| Ok(())).into_future())
             .context(ErrorKind::Tokio)
             .map_err(Error::from)


### PR DESCRIPTION
Fixes #35 .

It seems can work... I've tested it with the simplest reply bot.

What I've done is fetch the username through `get_me()` and when the command received ends with the username, remove the username & `@` from the command then process it as normal.

I've just leant Rust for several weeks so I may not using the best way 😂