### PR TITLE
Add support for webhooks mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ uuid = { version = "0.6", features = ["v4"] }
 telebot-derive = {version = "0.0.12", path = "./telebot-derive/"}
 log = "0.4"
 failure = "0.1.1"
+
+[dev-dependencies]
+env_logger = "0.5"

--- a/examples/push_print_everything.rs
+++ b/examples/push_print_everything.rs
@@ -1,0 +1,28 @@
+extern crate futures;
+extern crate telebot;
+extern crate tokio_core;
+extern crate env_logger;
+
+use telebot::RcBot;
+use tokio_core::reactor::Core;
+use futures::stream::Stream;
+use std::env;
+use futures::IntoFuture;
+
+fn main() {
+    env_logger::init();
+    // Create a new tokio core
+    let mut lp = Core::new().unwrap();
+
+    // Create the bot
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap());
+
+    let stream = bot.get_push_stream().and_then(|(_, msg)| {
+        println!("Received: {:#?}", msg);
+
+        Ok(())
+    });
+
+    // enter the main loop
+    lp.run(stream.for_each(|_| Ok(())).into_future()).unwrap();
+}


### PR DESCRIPTION
I wrote this before I realised that Telegram's polling API offered long polling, so webhooks mode isn't really that necessary. I considered throwing this code away but I guess you could see if you wanted it.

It's not exactly complete &mdash; webhooks mode also allows you to return a request directly as the response to a push, but there is no convenient way to do this (you need to manually construct the struct, add a `method` field, and then serialise it).