### PR TITLE
Share a client instead of creating one per request

### DIFF
--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -18,7 +18,7 @@ fn main() {
     let mut lp = Core::new().unwrap();
 
     // Create the bot
-    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).update_interval(200);
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).unwrap().update_interval(200);
 
     // Register a location command which will send a location to requests like /location 2.321 12.32
     enum LocationErr {
@@ -32,7 +32,7 @@ fn main() {
 
             if let Some(pos) = msg.text.take() {
                 let mut elms = pos.split_whitespace().take(2).filter_map(|x| x.parse::<f32>().ok());
-                
+
                 if let (Some(a), Some(l)) = (elms.next(), elms.next()) {
                     return Ok((bot, msg, a, l));
                 }

--- a/examples/inline_bot.rs
+++ b/examples/inline_bot.rs
@@ -19,7 +19,7 @@ fn main() {
     let mut lp = Core::new().unwrap();
 
     // Create the bot
-    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).update_interval(200);
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).unwrap().update_interval(200);
 
     let stream = bot.get_stream()
         .filter_map(|(bot, msg)| msg.inline_query.map(|query| (bot, query)))

--- a/examples/print_everything.rs
+++ b/examples/print_everything.rs
@@ -13,7 +13,7 @@ fn main() {
     let mut lp = Core::new().unwrap();
 
     // Create the bot
-    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).update_interval(200);
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).unwrap().update_interval(200);
 
     let stream = bot.get_stream().and_then(|(_, msg)| {
         println!("Received: {:#?}", msg);

--- a/examples/reply.rs
+++ b/examples/reply.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut lp = Core::new().unwrap();
 
     // Create the bot
-    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).update_interval(200);
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).unwrap().update_interval(200);
 
     // Register a reply command which answers a message
     let handle = bot.new_cmd("/reply").and_then(|(bot, msg)| {

--- a/examples/send_mediagroup.rs
+++ b/examples/send_mediagroup.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut lp = Core::new().unwrap();
 
     // Create the bot
-    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).update_interval(200);
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).unwrap().update_interval(200);
 
     let handle = bot.new_cmd("/send_mediagroup")
         .and_then(|(bot, msg)| {

--- a/examples/send_memory.rs
+++ b/examples/send_memory.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut lp = Core::new().unwrap();
 
     // Create the bot
-    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).update_interval(200);
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).unwrap().update_interval(200);
 
     let text = r"
 Dearest creature in creation,

--- a/examples/send_self.rs
+++ b/examples/send_self.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut lp = Core::new().unwrap();
 
     // Create the bot
-    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).update_interval(200);
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).unwrap().update_interval(200);
 
     let handle = bot.new_cmd("/send_self")
         .and_then(|(bot, msg)| {

--- a/examples/unknown_cmd.rs
+++ b/examples/unknown_cmd.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut lp = Core::new().unwrap();
 
     // Create the bot
-    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).update_interval(200);
+    let bot = RcBot::new(lp.handle(), &env::var("TELEGRAM_BOT_KEY").unwrap()).unwrap().update_interval(200);
 
     // Every possible command is unknown
     let handle = bot.unknown_cmd().and_then(|(bot, msg)| bot.message(msg.chat.id, "Unknown command".into()).send());


### PR DESCRIPTION
This lets Hyper's connection pooling actually work.

Unfortunately this is an API-breaking change. I'm not sure how you want to handle this...