### PR TITLE
closes #62, fix to_metadata to create metadata for single files, 

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -120,6 +120,14 @@ pub trait TryIntoFile: Sized {
     fn try_into(self) -> Result<File, Self::Error>;
 }
 
+impl TryIntoFile for File {
+    type Error = ();
+    
+    fn try_into(self) -> Result<File, Self::Error> {
+        Ok(self)
+    }
+}
+
 /// Construct a Telegram file from a local path
 impl<'a> TryIntoFile for &'a str {
     type Error = Error;

--- a/src/file.rs
+++ b/src/file.rs
@@ -35,8 +35,7 @@ impl FileList {
         if self.0.len() == 0 {
             None
         } else if self.0.len() == 1 {
-            //Some(MediaFile::SingleFile(self.0.iter().map(|x| x.file.name()).next().unwrap()))
-            None
+            Some(MediaFile::SingleFile(self.0.iter().map(|x| x.file.name()).next().unwrap()))
         } else {
             let entities = self.0.iter().map(|x| {
                 FileEntity::Photo {


### PR DESCRIPTION
It is impossible to send single files through the bot 
ex the query : 
```rust
bot.photo(msg.chat.id)
    .file(File::Url("https://upload.wikimedia.org/wikipedia/commons/f/f4/Honeycrisp.jpg".into()))
    .caption("hello there".to_owned())
    .send()
```
Creates an error : 
```
TelegramError { message: "Bad Request: there is no photo in the request" }

Telegram server responsed with an error

Telegram server responsed with an error
```

The reason is that in src/file.rs this line is commented in `fn to_metadata`
```rust 
} else if self.0.len() == 1 {
    // Some(MediaFile::SingleFile(self.0.iter().map(|x| x.file.name()).next().unwrap()))
    None
```
This means that no metadata is generated if there is only a single file to send (in case of SendPhoto, SendDocument, SendAudio and SendVideo, ...).

Also the trait TryIntoFile wich is the bound on the argument of `fn file` is not implemented for the enum File itself, wich makes it impossible to send files from url using `File::Url("Some url".into())`. Only in-memory data or disk data is sendable.